### PR TITLE
Add health endpoint that returns a 200 OK status

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ func main() {
 	e.Use(delayImageMiddleware)
 	e.Static("/", "static")
 
+	e.GET("/health", healthHandler)
+
 	if os.Getenv("HTTP2") != "" {
 		log.Printf("starting http2 server...")
 		//net/http.Server is a http1.1 server with optional http2 support
@@ -35,4 +37,8 @@ func delayImageMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 		return next(c)
 	}
+}
+
+func healthHandler(c echo.Context) error {
+	return c.String(http.StatusOK, "OK")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthHandler(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if assert.NoError(t, healthHandler(c)) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "OK", rec.Body.String())
+	}
+}


### PR DESCRIPTION
Add a health endpoint that returns a 200 OK status.

* **main.go**
  - Add a new route `/health` that returns a 200 OK status.
  - Create a new handler function `healthHandler` that returns a 200 OK status.

* **main_test.go**
  - Add a unit test for the `healthHandler` function using the `httptest` package to test the `/health` endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/onyxg/http_demo?shareId=927a6964-b7ad-413a-ab56-e0be8e049e14).