### PR TITLE
Add Docker Compose to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # HTTP 1.1 vs HTTP 2 Demo
 
 A simple demo to show the difference between HTTP 1.1 and HTTP 2.
@@ -29,4 +28,18 @@ Run the following command to the see the HTTP 2 / Established connections
 
 ```bash
 netstat -an | grep 9002
+```
+
+## Running with Docker Compose
+
+To run the project using Docker Compose, use the following commands:
+
+Start HTTP 1.1 server on port [localhost:9001](https://localhost:9001)
+```bash
+docker-compose up http1
+```
+
+Start HTTP 2 server on port [localhost:9002](https://localhost:9002)
+```bash
+docker-compose up http2
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  http1:
+    image: golang:1.23
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - HTTP2=
+    command: go run main.go
+    ports:
+      - "9001:9001"
+
+  http2:
+    image: golang:1.23
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - HTTP2=true
+    command: go run main.go
+    ports:
+      - "9002:9002"


### PR DESCRIPTION
Add Docker Compose support to the project

* Add `docker-compose.yml` file to define services for HTTP 1.1 and HTTP 2 servers
  - Define `http1` service using the Go Docker image
  - Define `http2` service using the Go Docker image
  - Mount the current directory as a volume in both services
  - Set the working directory to `/app` in both services
  - Use environment variables to differentiate between HTTP 1.1 and HTTP 2 servers
  - Expose ports 9001 and 9002 for HTTP 1.1 and HTTP 2 servers respectively

* Update `README.md` to include instructions for running the project using Docker Compose
  - Add commands to start HTTP 1.1 and HTTP 2 servers using Docker Compose

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/onyxg/http_demo?shareId=c1b134f6-4020-43aa-9e36-b5a1b1877df2).